### PR TITLE
Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,9 @@ docker exec -it 41ff96f4a1a6 mysqldump library > library_backup.sql
 docker exec -it 41ff96f4a1a6 mysql < library_backup.sql
 ```
 Эта команда позволяет восстановить все данные из файла library_backup.sql.
+
+Пересборка и запуск прокси
+```
+docker compose build manticore-proxy
+docker compose up -d
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,10 @@ services:
     container_name: library-manticore
     image: manticoresearch/manticore:13.6.7
     restart: always
-    # ports:
-    #   - "9308:9308" # Локально для отладки (необязательно)
+    ports:
+      - "9306:9306"
+      - "9308:9308" # Локально для отладки (необязательно)
+      - "9312:9312"
     networks:
       - library-net
     ulimits:
@@ -24,13 +26,7 @@ services:
     volumes:
       - ./manticore/data:/var/lib/manticore
       - ./manticore/logs:/var/log/manticore
-      # - ./manticore/conf/manticore.conf:/etc/manticoresearch/manticore.conf
-    # healthcheck:
-    #   test: ["CMD", "curl", "-f", "http://localhost:9308"]
-    #   interval: 3s
-    #   timeout: 5s
-    #   retries: 10
-    #   start_period: 10s
+      - ./manticore/conf/manticore.conf:/etc/manticoresearch/manticore.conf
 
   vectorizer:
     container_name: library-vectorizer
@@ -50,6 +46,32 @@ services:
         limits:
           memory: 16G
 
+  vectorizer_py:
+    container_name: library-vectorizer-py
+    build:
+      context: /home/audetv/dev/vectorizer_py/
+    restart: always
+    networks:
+      - library-net
+    environment:
+      - MODEL_NAME=intfloat/multilingual-e5-small
+      - DEVICE=cuda
+      - USE_FP16=1
+      - NORMALIZE=1
+      - MAX_TOKENS=510
+      - OVERLAP=128
+      - MIN_ADVANCE=50
+      - E5_PREFIX="query:"
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    ports:
+      - "8082:8082"   # внешний порт 8082 → внутри 8081
+
   manticore-proxy:
     container_name: library-manticore-proxy
     # image: library-manticore-proxy
@@ -63,15 +85,13 @@ services:
       - MANTICORE_API_KEY_FILE=/run/secrets/manticore_api_key
       - MANTICORE_HOST=manticore:9308 # Адрес Manticore в Docker-сети
       - VECTORIZER_HOST=http://vectorizer:8081
+      - VECTORIZER_PY_HOST=http://vectorizer_py:8082
     secrets:
       - manticore_api_key
     depends_on:
       - manticore
       - vectorizer
-
-# volumes:
-#   manticore:
-
+      # - vectorizer_py
 
 secrets:
   manticore_api_key:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,10 +17,10 @@ services:
       memlock:
         soft: -1
         hard: -1
-    deploy:
-      resources:
-        limits:
-          memory: 64G
+    # deploy:
+    #   resources:
+    #     limits:
+    #       memory: 64G
     environment:
       - EXTRA=1
     volumes:
@@ -68,15 +68,15 @@ services:
           devices:
             - driver: nvidia
               count: all
-              capabilities: [gpu]
+              capabilities: [ gpu ]
     ports:
-      - "8082:8082"   # внешний порт 8082 → внутри 8081
+      - "8082:8082" # внешний порт 8082 → внутри 8081
 
   manticore-proxy:
     container_name: library-manticore-proxy
     # image: library-manticore-proxy
     build: ./proxy
-    restart: always    
+    restart: always
     ports:
       - "1122:9308" # Наружу 1122 → внутри 9308
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,27 +1,10 @@
 services:
-  # app:
-  #   container_name: library-app
-  #   image: yiisoftware/yii2-php:8.1-apache
-  #   restart: always
-  #   environment:
-  #     APP_ENV: dev
-  #     FRONTEND_URL: 'http://localhost'
-  #     GH_REPO_URL: 'https://github.com/terratensor/kob-library-app'
-  #     MANTICORE_DB_NAME_COMMON: 'library2025'
-  #   volumes:
-  #     - ~/.composer-docker/cache:/root/.composer/cache:delegated
-  #     - ./webui/app:/app:delegated
-  #   ports:
-  #     - '80:80'
-  #   networks:
-  #     - library-net
-
   manticore:
     container_name: library-manticore
-    image: manticoresearch/manticore
+    image: manticoresearch/manticore:13.6.7
     restart: always
-    ports:
-      - "127.0.0.1:9308:9308" # Локально для отладки (необязательно)
+    # ports:
+    #   - "9308:9308" # Локально для отладки (необязательно)
     networks:
       - library-net
     ulimits:
@@ -35,19 +18,43 @@ services:
     deploy:
       resources:
         limits:
-          memory: 16G
+          memory: 64G
     environment:
       - EXTRA=1
     volumes:
       - ./manticore/data:/var/lib/manticore
       - ./manticore/logs:/var/log/manticore
-      # - manticore:/var/lib/manticore
-      # - manticore:/var/log/manticore    
+      # - ./manticore/conf/manticore.conf:/etc/manticoresearch/manticore.conf
+    # healthcheck:
+    #   test: ["CMD", "curl", "-f", "http://localhost:9308"]
+    #   interval: 3s
+    #   timeout: 5s
+    #   retries: 10
+    #   start_period: 10s
+
+  vectorizer:
+    container_name: library-vectorizer
+    build:
+      context: /mnt/work/audetv/go/src/github.com/terratensor/manticore-vectorizer/
+      dockerfile: Dockerfile
+    restart: always
+    networks:
+      - library-net
+    environment:
+      - CONFIG_FILE=config.yaml
+    volumes:
+      - /mnt/work/audetv/go/src/github.com/terratensor/manticore-vectorizer/config:/config
+      - /mnt/work/audetv/go/src/github.com/terratensor/manticore-vectorizer/vectors:/vectors
+    deploy:
+      resources:
+        limits:
+          memory: 16G
 
   manticore-proxy:
     container_name: library-manticore-proxy
+    # image: library-manticore-proxy
     build: ./proxy
-    restart: always
+    restart: always    
     ports:
       - "1122:9308" # Наружу 1122 → внутри 9308
     networks:
@@ -55,10 +62,12 @@ services:
     environment:
       - MANTICORE_API_KEY_FILE=/run/secrets/manticore_api_key
       - MANTICORE_HOST=manticore:9308 # Адрес Manticore в Docker-сети
+      - VECTORIZER_HOST=http://vectorizer:8081
     secrets:
       - manticore_api_key
     depends_on:
       - manticore
+      - vectorizer
 
 # volumes:
 #   manticore:
@@ -71,3 +80,4 @@ secrets:
 networks:
   library-net:
     name: library-net
+    driver: bridge

--- a/parser/config/local.yaml
+++ b/parser/config/local.yaml
@@ -1,11 +1,11 @@
 env: "local" # Окружение - local, dev или prod
 concurrency: 20
-metadata_only: false
+metadata_only: true
 volume: "../common/"
 genres_map_path: "./config/genres_map.csv"
 folders_map_path: "./config/folders_map.yaml"
 manticore:
-  engine: "rowwise" # rowwise, columnar
+  engine: "columnar" # rowwise, columnar
   host: "localhost"
   index: "library2025"
   port: 9308


### PR DESCRIPTION
### PR: Реализация обратного прокси-сервера

**Что сделано:**

Этот PR добавляет новый сервис `proxy` — обратный прокси-сервер на Go, который становится центральной точкой доступа к бэкенд-сервисам: Manticore и двум сервисам векторизации.

**Ключевые изменения:**

1.  **Маршрутизация запросов:**
    *   Запросы на эндпоинт `/vectorize` направляются на один из двух сервисов векторизации в зависимости от параметра `model` в теле запроса (`glove` -> `vectorizer`, `e5-small` -> `vectorizer-py`).
    *   Все остальные запросы (`/json/search`, `/json/insert` и т.д.) проксируются напрямую в Manticore.

2.  **Аутентификация:**
    *   Добавлена обязательная проверка API-ключа, передаваемого в заголовке `X-API-Key`. Запросы без валидного ключа отклоняются со статусом `401 Unauthorized`.

3.  **Конфигурация:**
    *   Сервис полностью настраивается через переменные окружения, что упрощает его развертывание в различных средах (см. обновленную документацию).

4.  **Надежность:**
    *   Реализован механизм ожидания доступности Manticore перед запуском прокси.
    *   Добавлен простой механизм повторных запросов при разрыве соединения (`broken pipe`, `connection reset by peer`), что повышает отказоустойчивость.

5.  **Документация:**
    *   В `README.md` добавлен подробный раздел, описывающий конфигурацию и использование нового прокси-сервера, включая описание эндпоинта `/vectorize` и необходимых переменных окружения.

**Как тестировать:**

1.  Собрать и запустить сервисы с помощью `docker-compose`.
2.  Убедиться, что прокси запускается и ожидает готовности Manticore.
3.  Отправить запрос к Manticore через прокси (например, на `/json/search`), указав заголовок `X-API-Key`.
4.  Отправить запрос на `/vectorize` с разными моделями и убедиться, что они корректно обрабатываются.
    ```bash
    curl -X POST http://localhost:9308/vectorize \
    -H "Content-Type: application/json" \
    -H "X-API-Key: <ваш_ключ>" \
    -d '{
      "text": "пример текста",
      "model": "glove"
    }'
    ```
